### PR TITLE
panel resize, order input bug fix, trade history responsive hide arrow

### DIFF
--- a/src/app/mainview.component.scss
+++ b/src/app/mainview.component.scss
@@ -25,7 +25,7 @@
   width: 100%;
   height: 100%;
   @include screen(lg) {
-    max-width: 300px;
+    max-width: 280px;
     /deep/ {
       //.bn-card {
       //  height: auto;
@@ -38,7 +38,7 @@
     }
   }
   @include screen(xl) {
-    max-width: 320px;
+    max-width: 280px;
   }
 }
 

--- a/src/app/orderform.component.html
+++ b/src/app/orderform.component.html
@@ -32,8 +32,8 @@
 
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="amount">Amount</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="amount">Amount</label>
+              <div class="col-7">
                 <input #amountInput
                        (keyup)="amountChanged($event)"
                        (paste)="amountChanged($event)"
@@ -48,8 +48,8 @@
             </div>
 
             <div class="input-group row" *ngIf="selectedOrderType == 'limit'">
-              <label class="col-4 col-form-label" for="limit">Limit Price</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="limit">Limit Price</label>
+              <div class="col-7">
                 <input (keyup)="calcPrice($event)"
                        class="form-control" name="limit" id="limit"
                        type="number" step="0.000001" pattern="\d+" inputmode="numeric"
@@ -59,8 +59,8 @@
             </div>
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="amount">Price</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="amount">Price</label>
+              <div class="col-7">
                 <input #amountInput
                        (keyup)="priceChanged($event)"
                        (paste)="priceChanged($event)"
@@ -75,8 +75,8 @@
             </div>
 
             <div class="input-group row" *ngIf="pricingEnabled">
-              <label class="col-4 col-form-label" for="amount">Price</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="amount">Price</label>
+              <div class="col-7">
                 <input disabled
                        *ngIf="!pricingAvailable"
                        class="form-control"
@@ -99,8 +99,8 @@
             </div>
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="total_calc">Total</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="total_calc">Total</label>
+              <div class="col-7">
                 <input #totalInput
                        class="form-control order-form-total-input"
                        name="total" id="total_calc" type="text"
@@ -114,8 +114,8 @@
             </div>
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="js-maker-address">{{symbols[0]}} Address</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="js-maker-address">{{symbols[0]}} Address</label>
+              <div class="col-7">
                 <input class="form-control"
                        style="padding-right:16px;"
                        name="total" id="js-maker-address" type="text"
@@ -129,8 +129,8 @@
             </div>
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="js-taker-address">{{symbols[1]}} Address</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="js-taker-address">{{symbols[1]}} Address</label>
+              <div class="col-7">
                 <input class="form-control"
                        style="padding-right:16px;"
                        name="total" id="js-taker-address" type="text"
@@ -144,8 +144,8 @@
             </div>
 
             <div class="input-group row">
-              <label class="col-4 col-form-label" for="js-order-id">Order ID</label>
-              <div class="col-8">
+              <label class="col-5 col-form-label" for="js-order-id">Order ID</label>
+              <div class="col-7">
                 <input class="form-control"
                        style="padding-right:16px;"
                        name="total" id="js-order-id" type="text"

--- a/src/app/orderform.component.scss
+++ b/src/app/orderform.component.scss
@@ -19,6 +19,15 @@ form {
   overflow: hidden;
 }
 
+#amount, #price, #total_calc {
+  padding-right: 52px !important;
+}
+.input-group-addon {
+  z-index: 1000;
+  background-color: $bn-blue-light4;
+  margin-top: 1px;
+  height: calc(100% - 2px);
+}
 .order-form-total-input {
   opacity: .5;
 }

--- a/src/app/tradehistory.component.scss
+++ b/src/app/tradehistory.component.scss
@@ -26,6 +26,15 @@ app-table {
   }
 
   .arrow-icon {
-    padding-right: 5px;
+    padding-right: 8px;
+    margin-left: -6px;
+    margin-bottom: 2px;
+    font-size: 0.9rem;
+    width: auto;
+    height: 8px;
+
+    @media(max-width: 1255px) {
+      display:none;
+    }
   }
 }

--- a/src/styles/utils/_variables.scss
+++ b/src/styles/utils/_variables.scss
@@ -7,7 +7,7 @@ $bn-blue-light: #4794FF;
 $bn-blue-light1: #006AFF;
 $bn-blue-light2: #0055CC; // not used
 $bn-blue-light3: #70ACFF;
-$bn-blue-light4: #133049;
+$bn-blue-light4: #133049; // input background
 $bn-blue-light5: #1e3a52;
 $bn-blue-light6: #67B0FB;
 $bn-blue-light7: #ADCFFF;


### PR DESCRIPTION
- Make Balances and Order Form panels slightly narrower so other panels have more room
- Adjust Order Form inputs so labels and values don't overlap
- Adjust padding on the arrows and hide them on smaller screen