### PR TITLE
update urls and add compatibility link

### DIFF
--- a/src/app/nav-bar/nav-bar.component.ts
+++ b/src/app/nav-bar/nav-bar.component.ts
@@ -79,7 +79,7 @@ export class NavBarComponent implements OnInit {
     e.preventDefault();
     if(window.electron.ipcRenderer.sendSync('updateError')) {
       const { openExternal } = window.electron.remote.shell;
-      openExternal('https://github.com/BlocknetDX/block-dx/releases/latest');
+      openExternal('https://github.com/blocknetdx/block-dx/releases/latest');
     } else {
       const status = window.electron.ipcRenderer.sendSync('checkForUpdates');
       switch(status) {

--- a/src/scripts/configuration/views/configuration-complete.js
+++ b/src/scripts/configuration/views/configuration-complete.js
@@ -69,7 +69,7 @@ class ConfigurationComplete extends RouterView {
     const updatingWallets = configurationType === configurationTypes.UPDATE_WALLETS;
     $('.js-blocknetWalletLink').on('click', e => {
       e.preventDefault();
-      remote.shell.openExternal('https://github.com/BlocknetDX/blocknet/releases/latest');
+      remote.shell.openExternal('https://github.com/blocknetdx/blocknet/releases/latest');
     });
     $('#js-backBtn').on('click', e => {
       e.preventDefault();

--- a/src/scripts/configuration/views/enter-blocknet-credentials.js
+++ b/src/scripts/configuration/views/enter-blocknet-credentials.js
@@ -177,7 +177,7 @@ class EnterBlocknetCredentials extends RouterView {
 
     $('.js-blocknetWalletLink').on('click', e => {
       e.preventDefault();
-      remote.shell.openExternal('https://github.com/BlocknetDX/blocknet/releases/latest');
+      remote.shell.openExternal('https://github.com/blocknetdx/blocknet/releases/latest');
     });
 
   }

--- a/src/scripts/configuration/views/select-setup-type.js
+++ b/src/scripts/configuration/views/select-setup-type.js
@@ -46,7 +46,7 @@ class SelectSetupType extends RouterView {
               <div class="col2-no-margin">
             
                 <p style="${styles.p}">Block DX is the fastest, most secure, most reliable, and most decentralized exchange, allowing for peer-to-peer trading directly from your wallet.</p>
-                <p style="${styles.p}"><strong>Prerequisites</strong>: Block DX requires the <a href="#" class="text-link js-blocknetWalletLink">latest Blocknet wallet</a> and the wallets of any assets you want to trade with.</p>
+                <p style="${styles.p}"><strong>Prerequisites</strong>: Block DX requires the <a href="#" class="text-link js-blocknetWalletLink">latest Blocknet wallet</a> and the wallets of any assets you want to trade with. These must be downloaded and installed before continuing. See the full list of <a href="#" class="text-link js-compatibleWalletsLink">compatible assets and wallet versions</a>.</p>
                 <div class="main-area" style="${styles.mainArea}">
                 
                   <div id="js-automaticCredentials" class="main-area-item" style="${styles.flexContainer}">
@@ -114,7 +114,11 @@ class SelectSetupType extends RouterView {
     };
     $('.js-blocknetWalletLink').on('click', e => {
       e.preventDefault();
-      remote.shell.openExternal('https://github.com/BlocknetDX/blocknet/releases/latest');
+      remote.shell.openExternal('https://github.com/blocknetdx/blocknet/releases/latest');
+    });
+    $('.js-compatibleWalletsLink').on('click', e => {
+      e.preventDefault();
+      remote.shell.openExternal('https://docs.blocknet.co/blockdx/listings/#listed-digital-assets');
     });
     $('#js-automaticCredentials').on('click', e => toggleCredentialGeneration(e, true));
     $('#js-manualCredentials').on('click', e => toggleCredentialGeneration(e, false));

--- a/src/scripts/configuration/views/select-wallets.js
+++ b/src/scripts/configuration/views/select-wallets.js
@@ -199,7 +199,7 @@ class SelectWallets extends RouterView {
 
     $('.js-blocknetWalletLink').on('click', e => {
       e.preventDefault();
-      remote.shell.openExternal('https://github.com/BlocknetDX/blocknet/releases/latest');
+      remote.shell.openExternal('https://github.com/blocknetdx/blocknet/releases/latest');
     });
 
   }

--- a/src/settings.html
+++ b/src/settings.html
@@ -193,7 +193,7 @@
       $('.js-blocknetWalletLink').on('click', e => {
         e.preventDefault();
         const { openExternal } = window.electron.remote.shell;
-        openExternal('https://github.com/BlocknetDX/blocknet/releases/latest');
+        openExternal('https://github.com/blocknetdx/blocknet/releases/latest');
       });
 
       $('form').on('submit', e => {


### PR DESCRIPTION
- Updated links to new Github URL (/BlocknetDX/ > /blocknetdx/)
- Specified in Quick/Expert selection instructions that the wallets must by installed before proceeding and added a link to the compatible wallets and versions