### PR TITLE
Update order form price calc trigger and error message

### DIFF
--- a/src/app/angular-popper/angular-popper.css
+++ b/src/app/angular-popper/angular-popper.css
@@ -1,11 +1,15 @@
 :host .angular-popper {
   position: absolute;
-  background: #FFC107;
+  /*background: #FFC107;*/
+  background: #fff;
   color: black;
+  font-size: 0.8rem;
   width: 150px;
-  border-radius: 3px;
+  /*border-radius: 3px;*/
+  border-radius: 0;
   box-shadow: 0 0 2px rgba(0,0,0,0.5);
-  padding: 10px;
+  /*padding: 10px;*/
+  padding: 8px;
   text-align: center;
 }
 
@@ -13,7 +17,8 @@
   width: 0;
   height: 0;
   border-style: solid;
-  border-color: #FFC107;
+  /*border-color: #FFC107;*/
+  border-color: #fff;
   position: absolute;
   margin: 5px;
 }

--- a/src/app/orderform.component.html
+++ b/src/app/orderform.component.html
@@ -61,7 +61,7 @@
             <div class="input-group row">
               <label class="col-4 col-form-label" for="amount">Price</label>
               <div class="col-8">
-                <input #amountInput
+                <input #priceInput
                        (keyup)="priceChanged($event)"
                        (paste)="priceChanged($event)"
                        (blur)="onNumberInputBlur($event, 'price')"
@@ -82,7 +82,7 @@
                        class="form-control"
                        type="text" pattern="\d+"
                        placeholder="N/A" />
-                <input #amountInput
+                <input #secondPriceInput
                        *ngIf="pricingAvailable"
                        [disabled]="!pricingAvailable"
                        (keyup)="secondPriceChanged($event)"
@@ -186,6 +186,14 @@
 
             <angular-popper *ngIf="amountPopperShow" [target]="amountInput" [placement]="'top'" [closeButton]="false">
               <span [textContent]="amountPopperText" content></span>
+            </angular-popper>
+
+            <angular-popper *ngIf="pricePopperShow" [target]="priceInput" [placement]="'top'" [closeButton]="false">
+              <span [textContent]="pricePopperText" content></span>
+            </angular-popper>
+
+            <angular-popper *ngIf="secondPricePopperShow" [target]="priceInput" [placement]="'top'" [closeButton]="false">
+              <span [textContent]="secondPricePopperText" content></span>
             </angular-popper>
 
             <angular-popper *ngIf="totalPopperShow" [target]="totalInput" [placement]="'top'" [closeButton]="false">

--- a/src/app/orderform.component.scss
+++ b/src/app/orderform.component.scss
@@ -22,16 +22,20 @@ form {
 .order-form-total-input {
   opacity: .5;
 }
+
 #js-order-id {
   opacity: .5;
 }
+
 .order-form-button:enabled:hover {
   opacity: .9;
 }
+
 .order-form-buy-button {
   background-color: rgba(255, 255, 255, 0.06);
   color: #4BF5C6;
 }
+
 .order-form-sell-button {
   background-color: rgba(255, 255, 255, 0.06);
   color: #FB7F70;
@@ -41,6 +45,7 @@ form {
   height: 8px;
   display: block;
 }
+
 
 //$popper-color: #f33;
 //.popper {

--- a/src/app/orderform.component.ts
+++ b/src/app/orderform.component.ts
@@ -161,6 +161,14 @@ export class OrderformComponent implements OnInit {
         showProp = 'amountPopperShow';
         textProp = 'amountPopperText';
         break;
+      case 'price':
+        showProp = 'pricePopperShow';
+        textProp = 'pricePopperText';
+        break;
+      case 'secondPrice':
+        showProp = 'secondPricePopperShow';
+        textProp = 'secondPricePopperText';
+        break;
       case 'total':
         showProp = 'totalPopperShow';
         textProp = 'totalPopperText';
@@ -227,6 +235,8 @@ export class OrderformComponent implements OnInit {
     } else if(e.type === 'paste') {
       e.target.value = price;
     }
+    const numeric = new Set(['0','1','2','3','4','5','6','7','8','9','.','Decimal','Backspace']);
+    if (!numeric.has(e.key)) return; // do not calculate price if not a numeric key
     if(!price) {
       this.model.totalPrice = '';
       this.model.secondPrice = '';
@@ -258,11 +268,13 @@ export class OrderformComponent implements OnInit {
     let fixed;
     if(!valid) {
       fixed = this.fixAmount(secondPrice);
-      if(!skipPopper) this.showPopper('price', 'You can only specify prices with at most 0.000001 precision.', 5000);
+      if(!skipPopper) this.showPopper('secondPrice', 'You can only specify prices with at most 0.000001 precision.', 5000);
       e.target.value = fixed;
     } else if(e.type === 'paste') {
       e.target.value = secondPrice;
     }
+    const numeric = new Set(['0','1','2','3','4','5','6','7','8','9','.','Decimal','Backspace']);
+    if (!numeric.has(e.key)) return; // do not calculate price if not a numeric key
     if(!secondPrice) {
       this.model.totalPrice = '';
       this.model.price = '';


### PR DESCRIPTION
- The price will not recalculate if pressing tab, shift, ctrl, alt, cmd, or arrow keys
- Updated design for error message when attempting to enter greater than 6 decimal precision and added it to the taker and market pricing input fields (the market pricing error shows on the taker input due to a separate bug)