### PR TITLE
Misc fixes

### DIFF
--- a/src/app/big-tooltip/big-tooltip.component.scss
+++ b/src/app/big-tooltip/big-tooltip.component.scss
@@ -3,6 +3,7 @@
   background-color: #fff;
   color: #000;
   padding: 20px;
+  padding-bottom: 10px;
   z-index: 10;
   font-size: 14px;
   border-radius: 5px;
@@ -16,5 +17,9 @@
   color: #333;
   margin-bottom: 15px;
 }
-.big-tooltip-message {
+.big-tooltip-message li {
+  padding-bottom: 15px;
+}
+.big-tooltip-message li:last-child {
+  padding-bottom: 0px;
 }

--- a/src/app/depth.component.scss
+++ b/src/app/depth.component.scss
@@ -11,6 +11,7 @@
   margin-top: -10px;
   display: inline;
   text-align: center;
+  text-shadow: 1px 1px #0f2742;
 }
 #midmarket-price {
   display: block;

--- a/src/app/mainview.component.html
+++ b/src/app/mainview.component.html
@@ -15,7 +15,7 @@
       <ul>
         <li><strong>Block DX uses "Exact" orders.</strong><br>At the moment Block DX only supports "Exact" orders, meaning that an order must be taken for the full amount. If you are a maker, you may want to place multiple smaller orders instead of one large order. If you are a taker, multiple orders cannot be combined and taken as a single order with this order type. Market and Limit orders will be supported in a future release.</li>
         <li><strong>Only assets of connected wallets can be traded.</strong><br>If you did not connect the wallet, in the right sidebar menu select the Add & Update Wallets link.</li>
-        <li><strong>Trading wallets must remain online and unlocked.</strong><br>Since trading is peer-to-peer, you must have the wallet of each traded asset installed, open, synced, unlocked, and online for the duration of the trade. This also applies to the Blocknet wallet since it's used to facilitate the orders.</li>
+        <li><strong>Trading wallets must remain online and unlocked.</strong><br>Since trading is peer-to-peer, you must have the wallet of each traded asset installed, open, synced, unlocked, and online for the duration of the trade. This also applies to the Blocknet wallet since it's used to facilitate even non-BLOCK orders.</li>
         <li><strong>Place orders using BTC pricing.</strong><br>You can place orders based off BTC pricing, which is more familiar. To enable this capability, from the sidebar menu select General Settings.</li>
       </ul>
     </app-big-tooltip>

--- a/src/app/nav-bar/nav-bar.component.html
+++ b/src/app/nav-bar/nav-bar.component.html
@@ -14,7 +14,7 @@
         <!--<li><a href="#">My Balances</a></li>-->
         <!--<li><a href="#">Setup Wallet</a></li>-->
         <li><a href="#" (click)="openGeneralSettings($event)">General Settings</a></li>
-        <li><a href="#" (click)="openConfigurationWizard($event)">Configuration</a></li>
+        <li><a href="#" (click)="openConfigurationWizard($event)">Add & Update Wallets</a></li>
         <!-- <li><a href="#" (click)="openSettings($event)">RPC Settings</a></li> -->
         <li><a href="#" (click)="checkForUpdates($event)">Check for Updates</a></li>
       </ul>

--- a/src/app/orderform.component.ts
+++ b/src/app/orderform.component.ts
@@ -196,7 +196,7 @@ export class OrderformComponent implements OnInit {
     let fixed;
     if(!valid) {
       fixed = this.fixAmount(amount);
-      if(!skipPopper) this.showPopper('amount', 'You can only specify amounts with at most 0.000001 precision.', 5000);
+      if(!skipPopper) this.showPopper('amount', 'You can only specify amounts with at most 6 decimal places.', 5000);
       e.target.value = fixed;
     } else if(e.type === 'paste') {
       e.target.value = amount;
@@ -230,7 +230,7 @@ export class OrderformComponent implements OnInit {
     let fixed;
     if(!valid) {
       fixed = this.fixAmount(price);
-      if(!skipPopper) this.showPopper('price', 'You can only specify prices with at most 0.000001 precision.', 5000);
+      if(!skipPopper) this.showPopper('price', 'You can only specify amounts with at most 6 decimal places.', 5000);
       e.target.value = fixed;
     } else if(e.type === 'paste') {
       e.target.value = price;
@@ -268,7 +268,7 @@ export class OrderformComponent implements OnInit {
     let fixed;
     if(!valid) {
       fixed = this.fixAmount(secondPrice);
-      if(!skipPopper) this.showPopper('secondPrice', 'You can only specify prices with at most 0.000001 precision.', 5000);
+      if(!skipPopper) this.showPopper('secondPrice', 'You can only specify amounts with at most 6 decimal places.', 5000);
       e.target.value = fixed;
     } else if(e.type === 'paste') {
       e.target.value = secondPrice;

--- a/src/app/tradehistory.component.scss
+++ b/src/app/tradehistory.component.scss
@@ -26,6 +26,15 @@ app-table {
   }
 
   .arrow-icon {
-    padding-right: 5px;
+    padding-right: 8px;
+    margin-left: -3px;
+    margin-bottom: 2px;
+    font-size: 0.9rem;
+    width: auto;
+    height: 8px;
+
+    @media(max-width: 1310px) {
+      display:none;
+    }
   }
 }

--- a/src/scripts/information/modules/introduction.js
+++ b/src/scripts/information/modules/introduction.js
@@ -15,7 +15,7 @@ const renderIntroduction = () => {
           <div class="section-header-text">Connected Wallets</div><div class="section-header-line"></div>
         </div>
         <p>
-          Since trading is peer-to-peer, you must have the wallet of each asset being traded installed, synced, and configured. Configuration was done when starting Block DX the first time, but you can reconfigure to add new wallets for trading using the Basic Setup menu link.
+          Since trading is peer-to-peer, you must have the wallet of each asset being traded installed, synced, and configured. Configuration was done when starting Block DX the first time, but you can reconfigure to add new wallets for trading using the Add & Update Wallets menu link.
         </p>
       </div>
       <div class="section">
@@ -23,7 +23,7 @@ const renderIntroduction = () => {
           <div class="section-header-text">Balances</div><div class="section-header-line"></div>
         </div>
         <p>
-          In the top left panel there is a list of your connected wallets and the available balances for trading. If a value doesn't match the balance shown in the respective wallet, it may be due to funds in your wallet being immature funds (due to staking), funds being in a non-legacy address (<em>see below</em>), or the wallet losing connection. If a wallet you configure is not showing in Balances, it may be because the wallet is locked. If the wallet is unlocked, then try reconfiguring using the Basic Setup menu link.
+          In the top left panel there is a list of your connected wallets and the available balances for trading. If a value doesn't match the balance shown in the respective wallet, it may be due to funds in your wallet being immature funds (due to staking), funds being in a non-legacy address (<em>see below</em>), or the wallet losing connection. If a wallet you configure is not showing in Balances, it may be because the wallet is locked. If the wallet is unlocked, then try reconfiguring using the Add & Update Wallets menu link.
         </p>
       </div>
       <div class="section">

--- a/src/styles/utils/_variables.scss
+++ b/src/styles/utils/_variables.scss
@@ -3,14 +3,14 @@ $bn-red: #FF7F71;
 $bn-blue1: #051937; // background
 $bn-blue2: #172e48; // panel headings
 $bn-blue3: #0f2742; // panel bodies
-$bn-blue-light: #4794FF;
-$bn-blue-light1: #006AFF;
+$bn-blue-light: #4794FF;  // sort icon
+$bn-blue-light1: #006AFF; // buttons, primary/nudge
 $bn-blue-light2: #0055CC; // not used
-$bn-blue-light3: #70ACFF;
-$bn-blue-light4: #133049;
-$bn-blue-light5: #1e3a52;
-$bn-blue-light6: #67B0FB;
-$bn-blue-light7: #ADCFFF;
+$bn-blue-light3: #70ACFF; // active tab, refresh/expand symbol hover color
+$bn-blue-light4: #133049; // input background, pair select scroll section background
+$bn-blue-light5: #1e3a52; // pair selector header and tab
+$bn-blue-light6: #67B0FB; // menu hover color
+$bn-blue-light7: #ADCFFF; // order form type select
 
 $open-sans: 'Open Sans', sans-serif;
 $roboto-mono: 'Roboto Mono', sans-serif;


### PR DESCRIPTION
- Clarification added to balance tooltip
- Order form precision error now says "...6 decimal places" rather than "0.000001 precision"
- Configuration menu link text changed to "Add & Update Wallets"
- References to the configure link in Getting Started have also been updated to say "Add & Update Wallets"
- Tooltip styling updated to add space inbetween the bullets
- Added contrast to mid-market price so it's easier to read when overlapping with the depth chart
- Trade history arrows now hidden on smaller window sizes